### PR TITLE
refactor: 네비게이션 컴포넌트 분리

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,10 @@
 {
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "paths": ["node_modules"]
+      }
+    }
+  },
   "extends": ["next/core-web-vitals", "prettier"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,7 +32,5 @@
     "_types": "Typescript",
     "_utils": "Utils",
     "(route)": "Routes"
-  },
-  "typescript.preferences.autoImportFileExcludePatterns": ["node_modules/*"],
-  "javascript.preferences.autoImportFileExcludePatterns": ["node_modules/*"]
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,5 +32,7 @@
     "_types": "Typescript",
     "_utils": "Utils",
     "(route)": "Routes"
-  }
+  },
+  "typescript.preferences.autoImportFileExcludePatterns": ["node_modules/*"],
+  "javascript.preferences.autoImportFileExcludePatterns": ["node_modules/*"]
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.9.0",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-checkbox": "^1.1.1",
     "@radix-ui/react-label": "^2.1.0",
@@ -29,10 +30,12 @@
     "next-themes": "^0.3.0",
     "react": "^18",
     "react-dom": "^18",
+    "react-hook-form": "^7.52.1",
     "react-icons": "^5.2.1",
     "react-paginate": "^8.2.0",
     "tailwind-merge": "^2.4.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@hookform/resolvers':
+    specifier: ^3.9.0
+    version: 3.9.0(react-hook-form@7.52.1)
   '@radix-ui/react-accordion':
     specifier: ^1.2.0
     version: 1.2.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
@@ -59,6 +62,9 @@ dependencies:
   react-dom:
     specifier: ^18
     version: 18.3.1(react@18.3.1)
+  react-hook-form:
+    specifier: ^7.52.1
+    version: 7.52.1(react@18.3.1)
   react-icons:
     specifier: ^5.2.1
     version: 5.2.1(react@18.3.1)
@@ -71,6 +77,9 @@ dependencies:
   tailwindcss-animate:
     specifier: ^1.0.7
     version: 1.0.7(tailwindcss@3.4.6)
+  zod:
+    specifier: ^3.23.8
+    version: 3.23.8
 
 devDependencies:
   '@faker-js/faker':
@@ -1538,6 +1547,14 @@ packages:
 
   /@floating-ui/utils@0.2.5:
     resolution: {integrity: sha512-sTcG+QZ6fdEUObICavU+aB3Mp8HY4n14wYHdxK4fXjPmv3PXZZeY5RaguJmGyeH/CJQhX3fqKUtS4qc1LoHwhQ==}
+    dev: false
+
+  /@hookform/resolvers@3.9.0(react-hook-form@7.52.1):
+    resolution: {integrity: sha512-bU0Gr4EepJ/EQsH/IwEzYLsT/PEj5C0ynLQ4m+GSHS+xKH4TfSelhluTgOaoc4kA5s7eCsQbM4wvZLzELmWzUg==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
+    dependencies:
+      react-hook-form: 7.52.1(react@18.3.1)
     dev: false
 
   /@humanwhocodes/config-array@0.11.14:
@@ -5631,6 +5648,15 @@ packages:
       scheduler: 0.23.2
     dev: false
 
+  /react-hook-form@7.52.1(react@18.3.1):
+    resolution: {integrity: sha512-uNKIhaoICJ5KQALYZ4TOaOLElyM+xipord+Ha3crEFhTntdLvWZqVY49Wqd/0GiVCA/f9NjemLeiNPjG7Hpurg==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+    dependencies:
+      react: 18.3.1
+    dev: false
+
   /react-icons@5.2.1(react@18.3.1):
     resolution: {integrity: sha512-zdbW5GstTzXaVKvGSyTaBalt7HSfuK5ovrzlpyiWHAFXndXTdd/1hdDHI4xBM1Mn7YriT6aqESucFl9kEXzrdw==}
     peerDependencies:
@@ -6452,3 +6478,7 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+    dev: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/src/app/(after-login)/(quiz)/questions/page.tsx
+++ b/src/app/(after-login)/(quiz)/questions/page.tsx
@@ -2,16 +2,24 @@
 
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
-
+import { useForm } from 'react-hook-form';
 import { Checkbox } from '@/components/ui/checkbox';
 import SearchInput from '@/components/common/Monocles/SearchInput';
 import StarsRating from '@/app/(after-login)/(quiz)/questions/_components/StarsRating';
 import CustomPagination from '@/app/(after-login)/(quiz)/questions/_components/CustomPagination';
 import Link from 'next/link';
+import { zodResolver } from '@hookform/resolvers/zod';
 
 interface Item {
   id: number;
   title: string;
+}
+
+export interface FormInput {
+  inputField: string;
+  account: string;
+  role: string;
+  [key: string]: any;
 }
 
 export default function Page() {
@@ -38,6 +46,14 @@ export default function Page() {
     }
   };
 
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitted },
+  } = useForm<FormInput>({
+    criteriaMode: 'all',
+    mode: 'onBlur',
+  });
   useEffect(() => {
     const page = Number(searchParams.get('page')) || 1;
     fetchItems(page);
@@ -50,7 +66,7 @@ export default function Page() {
       {/* TODO: 이부분 전역 상태로 저장했다가
       추후 검색버튼 누르면 쿼리 스트링에 삽입, 이러면 서버 사이드 랜더링도 안깨짐.  */}
       {/* filter */}
-      <div className="mb-10 flex w-5/6 flex-col items-start justify-between gap-3 self-center justify-self-center text-nowrap rounded-md bg-white px-5 md:flex-row md:items-center">
+      <form className="mb-10 flex w-5/6 flex-col items-start justify-between gap-3 self-center justify-self-center text-nowrap rounded-md bg-white px-5 md:flex-row md:items-center">
         <p className="self-center md:self-start">필터</p>
         <div className="flex items-center">
           <Checkbox />
@@ -60,25 +76,18 @@ export default function Page() {
           <Checkbox />
           <p className="ml-2">모르는 문제</p>
         </div>
-        <div className="flex items-center gap-3">
-          <Checkbox />
-          <StarsRating className="w-3" />
-        </div>
-        <div className="flex items-center gap-3">
-          <Checkbox />
-          <StarsRating
-            className="w-3"
-            rating={2}
-          />
-        </div>
-        <div className="*: flex items-center gap-3">
-          <Checkbox />
-          <StarsRating
-            className="w-3"
-            rating={3}
-          />
-        </div>
-      </div>
+        {Array.from({ length: 3 }, (_, index) => (
+          <div
+            key={index}
+            className="flex items-center gap-3">
+            <Checkbox />
+            <StarsRating
+              className="w-3"
+              rating={(index + 1) as 1 | 2 | 3}
+            />
+          </div>
+        ))}
+      </form>
       {/* contents */}
       {items && items.length > 0 ? (
         <ul className="space-y-4">

--- a/src/components/navigations/Navigation.tsx
+++ b/src/components/navigations/Navigation.tsx
@@ -1,22 +1,11 @@
 'use client';
-
-import { useTheme } from 'next-themes';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import * as PopoverRadix from '@radix-ui/react-popover';
-import { LocalIcon } from '@/asset/icon';
-import { Button } from '@/components/ui/button';
 import { usePathname } from 'next/navigation';
-import NavPopOver from '@/components/navigations/components/NavPopOver';
 import NavMenu from '@/components/navigations/components/NavMenu';
 
 export default function Navigation() {
-  // 다크모드를 위한 기능.
-  const { theme, setTheme } = useTheme();
-
   const pathname = usePathname();
-  // 특정 URL 경로 정의
+  // 감출 컴포넌트 url
   const hideComponents = ['/test', '/another-url']; // URL 경로 목록
-
   const showBackButton = hideComponents.includes(pathname);
 
   return (
@@ -30,7 +19,6 @@ export default function Navigation() {
         </a>
         {!showBackButton && <p className="hidden md:block">IT 기술면접을 위한 CS지식 랜덤 퀴즈</p>}
       </div>
-
       <NavMenu />
     </nav>
   );

--- a/src/components/navigations/Navigation.tsx
+++ b/src/components/navigations/Navigation.tsx
@@ -5,9 +5,20 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import * as PopoverRadix from '@radix-ui/react-popover';
 import { LocalIcon } from '@/asset/icon';
 import { Button } from '@/components/ui/button';
+import { usePathname } from 'next/navigation';
+import NavPopOver from '@/components/navigations/components/NavPopOver';
+import NavMenu from '@/components/navigations/components/NavMenu';
 
 export default function Navigation() {
+  // 다크모드를 위한 기능.
   const { theme, setTheme } = useTheme();
+
+  const pathname = usePathname();
+  // 특정 URL 경로 정의
+  const hideComponents = ['/test', '/another-url']; // URL 경로 목록
+
+  const showBackButton = hideComponents.includes(pathname);
+
   return (
     <nav className="flex justify-between text-nowrap px-2 py-6 md:px-8">
       {/* logo, description */}
@@ -17,51 +28,10 @@ export default function Navigation() {
           className="bg-slate-300 px-5 py-2">
           Knowing
         </a>
-        <p className="hidden md:block">IT 기술면접을 위한 CS지식 랜덤 퀴즈</p>
+        {!showBackButton && <p className="hidden md:block">IT 기술면접을 위한 CS지식 랜덤 퀴즈</p>}
       </div>
-      <div className="flex items-center justify-center gap-3">
-        <Button
-          variant={'none'}
-          className="p-0 font-bold">
-          <p>랜덤퀴즈</p>
-          <LocalIcon name="LiaRandomSolid" />
-        </Button>
-        <Popover>
-          <PopoverTrigger>
-            <LocalIcon
-              name="FaUserAlt"
-              size={28}
-            />
-          </PopoverTrigger>
-          <PopoverContent
-            className="border-0 border-gray-200 stroke-gray-200 p-0 drop-shadow-md"
-            side="bottom">
-            <div className="w-full border-b-2 p-3">전체 학습 진도</div>
-            <div className="flex w-full divide-x-2">
-              <div className="w-full p-2">마이 페이지</div>
-              <div className="w-full p-2">로그인</div>
-            </div>
-            <PopoverRadix.Arrow
-              width={20}
-              height={11}
-              className="PopoverArrow fill-popover stroke-none drop-shadow"
-            />
-          </PopoverContent>
-        </Popover>
-        <LocalIcon
-          name="RxHamburgerMenu"
-          size={28}
-        />
-      </div>
-      {/* <select
-        className="bg-background"
-        value={theme}
-        onChange={e => setTheme(e.target.value)}>
-        <option value="system">System</option>
-        <option value="dark">Dark</option>
-        <option value="light">Light</option>
-        <option value="blue">blue</option>
-      </select> */}
+
+      <NavMenu />
     </nav>
   );
 }

--- a/src/components/navigations/components/NavMenu.tsx
+++ b/src/components/navigations/components/NavMenu.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { LocalIcon } from '@/asset/icon';
+import { Button } from '@/components/ui/button';
+import NavPopOver from '@/components/navigations/components/NavPopOver';
+
+export default function NavMenu() {
+  // prettier-ignore
+  const menu = [
+    '마이페이지',
+    '의견보내기',
+    '후원하기',
+    '이용약관'];
+
+  return (
+    <div className="flex items-center justify-center gap-6">
+      <NavPopOver
+        popoverTrigger={
+          <>
+            <Button
+              variant={'none'}
+              className="p-0 font-bold">
+              <p>랜덤퀴즈</p>
+              <LocalIcon name="LiaRandomSolid" />
+            </Button>
+          </>
+        }
+        popoverContent={
+          <>
+            <div className="flex w-full divide-x-2 text-nowrap text-center">
+              <div className="w-full p-2">모든 문제</div>
+              <div className="w-full p-2">모르는 문제</div>
+            </div>
+          </>
+        }
+      />
+
+      <NavPopOver
+        popoverTrigger={
+          <LocalIcon
+            name="FaUserAlt"
+            size={28}
+          />
+        }
+        popoverContent={
+          <>
+            <div className="w-full border-b-2 p-3">전체 학습 진도</div>
+            <div className="flex w-full divide-x-2 text-nowrap text-center">
+              <div className="w-full p-2">마이 페이지</div>
+              <div className="w-full p-2">로그인</div>
+            </div>
+          </>
+        }
+      />
+
+      <NavPopOver
+        popoverTrigger={
+          <LocalIcon
+            name="RxHamburgerMenu"
+            size={28}
+          />
+        }
+        popoverContent={
+          <>
+            <div className="flex w-full flex-col divide-y-2 text-nowrap text-center">
+              {menu.map((menu, index) => (
+                <div
+                  key={index}
+                  className="w-full px-10 py-3">
+                  {menu}
+                </div>
+              ))}
+            </div>
+          </>
+        }
+      />
+    </div>
+  );
+}

--- a/src/components/navigations/components/NavMenu.tsx
+++ b/src/components/navigations/components/NavMenu.tsx
@@ -2,8 +2,11 @@ import React from 'react';
 import { LocalIcon } from '@/asset/icon';
 import { Button } from '@/components/ui/button';
 import NavPopOver from '@/components/navigations/components/NavPopOver';
+import { useTheme } from 'next-themes';
 
 export default function NavMenu() {
+  // 다크모드를 위한 기능.
+  const { theme, setTheme } = useTheme();
   // prettier-ignore
   const menu = [
     '마이페이지',
@@ -16,12 +19,10 @@ export default function NavMenu() {
       <NavPopOver
         popoverTrigger={
           <>
-            <Button
-              variant={'none'}
-              className="p-0 font-bold">
+            <div className="flex items-center font-bold">
               <p>랜덤퀴즈</p>
               <LocalIcon name="LiaRandomSolid" />
-            </Button>
+            </div>
           </>
         }
         popoverContent={

--- a/src/components/navigations/components/NavPopOver.tsx
+++ b/src/components/navigations/components/NavPopOver.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import * as PopoverRadix from '@radix-ui/react-popover';
+import { cn } from '@/lib/utils';
+
+export default function NavPopOver({
+  popoverTrigger,
+  popoverContent,
+  popoverContentWrapperClass,
+}: {
+  popoverTrigger: React.ReactNode;
+  popoverContent: React.ReactNode;
+  popoverContentWrapperClass?: string;
+}) {
+  return (
+    <Popover>
+      <PopoverTrigger>{popoverTrigger}</PopoverTrigger>
+      <PopoverContent
+        className={cn('w-fit border-0 border-gray-200 stroke-gray-200 p-0 drop-shadow-md', popoverContentWrapperClass)}
+        side="bottom">
+        {popoverContent}
+        <PopoverRadix.Arrow
+          width={20}
+          height={11}
+          className="PopoverArrow fill-popover stroke-none drop-shadow"
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}


### PR DESCRIPTION
## 🧾 관련 이슈
close : #17 
 

## 🔎 구현한 내용
네비게이션 플로팅 ui와 컴포넌트 분리 및 pathname 상수화


## 📸 스크린샷(선택사항)



## 🙌 리뷰어에게


